### PR TITLE
Fix MNN error and preds indices

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -29,12 +29,15 @@ class Classifier():
         # cv2 read shape is NHWC, Tensor's need is NCHW,transpose it
         image = image.transpose((2, 0, 1))
 
+        # convert image to float32 instead of float64, otherwise MNN will throw an error
+        image = image.astype(np.float32)
+
         # construct tensor from np.ndarray
         tmp_input = MNN.Tensor((1, 3, 224, 224), MNN.Halide_Type_Float, image, MNN.Tensor_DimensionType_Caffe)
         self.input_tensor.copyFrom(tmp_input)
         self.interpreter.runSession(self.session)
         output_tensor = self.interpreter.getSessionOutput(self.session)
-        preds = output_tensor.getData()
+        preds = output_tensor.getData()[0]
 
         top = 1
         top_indices = np.array(preds).argsort()[-top:][::-1]


### PR DESCRIPTION
1) 32-34
MNN requires numpy array as np.float32, not np.float64. Otherwise it will throw an error:

> terminate called after throwing an instance of 'std::runtime_error'
>   what():  numpy type does not match
> Aborted (core dumped)

Solution was find there: https://github.com/Linzaer/Ultra-Light-Fast-Generic-Face-Detector-1MB/issues/197

2) 40
Array "preds" has shape (1, 397), and if we don't choose the first and only vector, we will get errors with slicing in the return block.